### PR TITLE
Triggerfehler gefixt

### DIFF
--- a/mg.mud.de/info.tf
+++ b/mg.mud.de/info.tf
@@ -129,7 +129,7 @@
 		/setprop guild $$[tolower({P1})]%%;\
 		/setprop guild_level %%P2%;\
 	/def -p20 -1 -q -ag -mregexp -t'^Erfahrung \\\\.\\\\.\\\\.\\\\.\\\\.\
-		\\\\.\\\\.\\\\. +([0-9]+) Punkte +Charakter|Gesinnung \\\\.\\\\.\\\\.\
+		\\\\.\\\\.\\\\. +([0-9]+) Punkte +(Charakter|Gesinnung) \\\\.\\\\.\\\\.\
        		\\\\.\\\\.\\\\.\\\\.\\\\. ([a-z]+)$$' Info_6=\
 		/if (!INFO_EP_BASE) /set INFO_EP_BASE %%P1%%; /endif%%;\
 		/if (!p_ep) /setprop ep %%P1%%; /endif%%;\
@@ -139,7 +139,7 @@
 			/set INFO_EP_DIFF_SHORT %%INFO_EP_DIFF_LONG%%;\
 		/endif%%;\
 		/setprop ep %%P1%%;\
-		/setprop align %%P2%;\
+		/setprop align %%P3%;\
 	/def -Fp24 -1 -q -ag -mregexp -t'Geschicklichkeit \\\\. +([0-9]+)\
 		( +\\\\(([-+0-9]+)\\\\))?' Info_7=\
 		/setprop base_dex %%P1%%;\


### PR DESCRIPTION
Die neue Version von Info mit "Gesinnung" wurde noch nicht richtig
erkannt. Aktuell sind beide in Umlauf, daher kann die alte erst nach dem
naechsten Reboot entfernt werden.