### PR TITLE
more_prompt zurücksetzen

### DIFF
--- a/magier.tf
+++ b/magier.tf
@@ -77,6 +77,8 @@
         /send f%;\
      /else \
         /set more_prompt=1%;\
+        /def -q -1 -mglob -h"PROMPT *>*" -Fp1 t_more_done = \
+          /set more_prompt=0%; \
      /endif
 
 /def completion_object = \


### PR DESCRIPTION
Durch das fehlende Zurücksetzen wird ein f zum Weiterblättern ans Mud gesendet, auch wenn dies nicht nötig ist. In diesen Fällen wird das f als normales Kommando ausgewertet und es kommt zu unerwarteten Meldungen.